### PR TITLE
Adding max response payload size property documentation

### DIFF
--- a/src/_data/snPropertiesLocal.json
+++ b/src/_data/snPropertiesLocal.json
@@ -3101,6 +3101,20 @@
     "sysid": "17532ec50f0230102a86e3d1df767ea2"
   },
   {
+    "name": "glide.pf.rest.response_payload_max_size",
+    "actualName": "glide.pf.rest.response_payload_max_size",
+    "description": "Controls the allowed payload size of responses to REST API calls. By default, the allowed payload size for a REST response is 5MB (5120KB). The max value allowed for this property is `10240` (10MB, or 10240KB). If the respective flow is configured to use a MID Server, you would add the respective property to the MID Server properties table and not [sys_properties]. Configuring this property may address error messages related to REST response payload size, however if the payload size exceeds the maximum 10MB, the payload must be saved as an attachment.",
+    "value": "5120",
+    "sysid": "-1"
+  },
+  {
+    "name": "glide.pf.soap.response_payload_max_size",
+    "actualName": "glide.pf.soap.response_payload_max_size",
+    "description": "Controls the allowed payload size of responses to SOAP API calls. By default, the allowed payload size for a SOAP response is 5MB (5120KB). The max value allowed for this property is `10240` (10MB, or 10240KB). If the respective flow is configured to use a MID Server, you would add the respective property to the MID Server properties table and not [sys_properties]. Configuring this property may address error messages related to SOAP response payload size, however if the payload size exceeds the maximum 10MB, the payload must be saved as an attachment.",
+    "value": "5120",
+    "sysid": "-1"
+  },
+  {
     "name": "com.glide.platform_ml.enable_sys_service_route",
     "actualName": "com.glide.platform_ml.enable_sys_service_route",
     "description": "Boolean system property for enabling/disabling sys_service route to get prediction server url for workflow capability.",

--- a/src/_data/snPropertiesLocal.json
+++ b/src/_data/snPropertiesLocal.json
@@ -3099,21 +3099,7 @@
     "description": "Flag to enable the Start with Delay feature in Process Automation Designer",
     "value": "true",
     "sysid": "17532ec50f0230102a86e3d1df767ea2"
-  },
-  {
-    "name": "glide.pf.rest.response_payload_max_size",
-    "actualName": "glide.pf.rest.response_payload_max_size",
-    "description": "Controls the allowed payload size of responses to REST API calls. By default, the allowed payload size for a REST response is 5MB (5120KB). The max value allowed for this property is `10240` (10MB, or 10240KB). If the respective flow is configured to use a MID Server, you would add the respective property to the MID Server properties table and not [sys_properties]. Configuring this property may address error messages related to REST response payload size, however if the payload size exceeds the maximum 10MB, the payload must be saved as an attachment.",
-    "value": "5120",
-    "sysid": "-1"
-  },
-  {
-    "name": "glide.pf.soap.response_payload_max_size",
-    "actualName": "glide.pf.soap.response_payload_max_size",
-    "description": "Controls the allowed payload size of responses to SOAP API calls. By default, the allowed payload size for a SOAP response is 5MB (5120KB). The max value allowed for this property is `10240` (10MB, or 10240KB). If the respective flow is configured to use a MID Server, you would add the respective property to the MID Server properties table and not [sys_properties]. Configuring this property may address error messages related to SOAP response payload size, however if the payload size exceeds the maximum 10MB, the payload must be saved as an attachment.",
-    "value": "5120",
-    "sysid": "-1"
-  },
+  }, 
   {
     "name": "com.glide.platform_ml.enable_sys_service_route",
     "actualName": "com.glide.platform_ml.enable_sys_service_route",
@@ -12472,6 +12458,20 @@
     "description": "Query execution percent improvement threshold",
     "value": "20",
     "sysid": "f947c584c33032009f1d3e5474d3ae91"
+  },
+  {
+    "name": "glide.pf.rest.response_payload_max_size",
+    "actualName": "glide.pf.rest.response_payload_max_size",
+    "description": "Controls the allowed payload size of responses to REST API calls. By default, the allowed payload size for a REST response is 5MB (5120KB). The max value allowed for this property is `10240` (10MB, or 10240KB). If the respective flow is configured to use a MID Server, you would add the respective property to the MID Server properties table and not [sys_properties]. Configuring this property may address error messages related to REST response payload size, however if the payload size exceeds the maximum 10MB, the payload must be saved as an attachment.",
+    "value": "5120",
+    "sysid": "-1"
+  },
+  {
+    "name": "glide.pf.soap.response_payload_max_size",
+    "actualName": "glide.pf.soap.response_payload_max_size",
+    "description": "Controls the allowed payload size of responses to SOAP API calls. By default, the allowed payload size for a SOAP response is 5MB (5120KB). The max value allowed for this property is `10240` (10MB, or 10240KB). If the respective flow is configured to use a MID Server, you would add the respective property to the MID Server properties table and not [sys_properties]. Configuring this property may address error messages related to SOAP response payload size, however if the payload size exceeds the maximum 10MB, the payload must be saved as an attachment.",
+    "value": "5120",
+    "sysid": "-1"
   },
   {
     "name": "glide.pg.any_rejection_rejects",


### PR DESCRIPTION
Adding property entries for:
glide.pf.rest.response_payload_max_size
glide.pf.soap.response_payload_max_size

Added information to description that was sourced from ServiceNow authored [KB article](https://support.servicenow.com/kb?id=kb_article_view&sysparm_article=KB0852968). For purposes of discoverability via keyword match in search engine results, I included the general error message that led to me needing to find and configure these properties.

These properties are not set OOB, therefore I set "sysid" to "-1" to reflect the fact that users will need to create the property if configuring.